### PR TITLE
check if watchers are available

### DIFF
--- a/lib/Store.js
+++ b/lib/Store.js
@@ -95,9 +95,11 @@ Store.prototype = extend(Store.prototype, {
   },
 
   _notify: function(keys, oldState, newState) {
-    this.watchers.forEach(function (w) {
-      w(keys, oldState, newState);
-    });
+    if (this.watchers) {
+      this.watchers.forEach(function (w) {
+        w(keys, oldState, newState);
+      });
+    }
   },
 
   addWatch: function (watcher) {


### PR DESCRIPTION
Fixes issues with server side rendering in case actions got triggered, as the watchers collection are defined only at the browser after mounting at the DOM.