### PR TITLE
return the result of actions

### DIFF
--- a/lib/Action.js
+++ b/lib/Action.js
@@ -1,3 +1,4 @@
+var Promise = require('bluebird');
 var extend = require('lodash-node/modern/objects/assign');
 var util = require('util');
 var fnNameFromServiceName = require('./convertName');
@@ -36,9 +37,11 @@ Action.prototype = extend(Action.prototype, {
         return pair[1].apply(self, Array.prototype.slice.call(arguments))
           .then(function (result) {
             self.dispatchAction(serviceName+'_COMPLETED', result);
+            return Promise.resolve(result);
           })
           .catch(function (err) {
             self.dispatchAction(serviceName+'_FAILED', err);
+            return Promise.reject(err);
           });
       };
     });


### PR DESCRIPTION
There are some use cases where the promise success/failure of an action should not only invoke stores, but also trigger other handlers based on the original result. Since the dispatcher doesn't return promises directly its added to the `Action.js`.