### PR TITLE
prevent payload wrapping on dispatch queue

### DIFF
--- a/lib/Dispatcher.js
+++ b/lib/Dispatcher.js
@@ -92,14 +92,13 @@ Dispatcher.prototype = extend(Dispatcher.prototype, {
       return;
     }
 
-    if (arguments.length > 2) {
-      payload = Array.prototype.slice.call(arguments, 1);
-    }
-    else {
-      payload = [payload];
-    }
-
     if (!this._currentDispatch || this._currentDispatch.isResolved()) {
+      if (arguments.length > 2) {
+        payload = Array.prototype.slice.call(arguments, 1);
+      }
+      else {
+        payload = [payload];
+      }
         this._currentDispatch = Promise.map(
             handlers,
             function (handler, idx) {

--- a/lib/Dispatcher.js
+++ b/lib/Dispatcher.js
@@ -99,13 +99,13 @@ Dispatcher.prototype = extend(Dispatcher.prototype, {
       else {
         payload = [payload];
       }
-        this._currentDispatch = Promise.map(
-            handlers,
-            function (handler, idx) {
-              return self._activatePromise(idx, handler, payload);
-            }
-        );
-        this._currentDispatch.finally(this._processQueue.bind(this));
+      this._currentDispatch = Promise.map(
+        handlers,
+        function (handler, idx) {
+          return self._activatePromise(idx, handler, payload);
+        }
+      );
+      this._currentDispatch.finally(this._processQueue.bind(this));
     }
     else {
       this._dispatchQueue.push({action: action, payload: payload});


### PR DESCRIPTION
The passed data should only be wrapped before there actually used, doing it earlier can create multiple nestings.